### PR TITLE
Change disconnection message to translatable component

### DIFF
--- a/Minescript-Plus/minescript_plus.py
+++ b/Minescript-Plus/minescript_plus.py
@@ -828,8 +828,7 @@ class Client:
         This function calls the network handler's disconnect method, passing a literal text message
         to indicate that the disconnection was initiated by the user.
         """
-        mc.player.connection.getConnection().disconnect(
-            Component.literal("Disconnected by user"))
+        mc.player.connection.getConnection().disconnect(Component.translatable("multiplayer.disconnect.generic"))
 
     @staticmethod
     def get_options():


### PR DESCRIPTION
This line, in Client.disconnect():
mc.player.connection.getConnection().disconnect(
    Component.literal("Disconnected by user"))

Should actually be
mc.player.connection.getConnection().disconnect(Component.translatable("multiplayer.disconnect.generic"))