### PR TITLE
Fixed bug where Hud could create text with the same id as another text object (same for items)

### DIFF
--- a/Minescript-Plus/minescript_plus.py
+++ b/Minescript-Plus/minescript_plus.py
@@ -1647,6 +1647,8 @@ _texts: dict[int, tuple[bool, str, int, int, int, int, int, int, float, bool, bo
 _ti: int = 0
 _items: dict[int, tuple[bool, str, int, int, str, float, float, float, list]] = {}
 _ii: int = 0
+_free_text_ids: list[int] = []
+_free_item_ids: list[int] = []
 
 def _check_ver(ver: str) -> bool:
     _mc_ver = version_info().minecraft
@@ -1677,10 +1679,16 @@ def update_tuple(old_tuple, new_values):
 def _add_text(*t):
     global _texts
     global _ti
+    global _free_text_ids
     
-    _texts[_ti] = tuple(t)
-    _ti += 1
-    return _ti - 1
+    if _free_text_ids:
+        idx = _free_text_ids.pop()
+    else:
+        idx = _ti
+        _ti += 1
+    
+    _texts[idx] = tuple(t)
+    return idx
 
 def _update_text(index: int, *t):
     global _texts
@@ -1707,10 +1715,10 @@ def _set_text_position(index: int, x: int, y: int):
     
 def _remove_text(i):
     global _texts
-    global _ti
-
+    global _free_text_ids
+    
     del _texts[i]
-    _ti -= 1
+    _free_text_ids.append(i)
 
 def _clear_texts():
     global _texts
@@ -1762,10 +1770,16 @@ def _get_item_name(item: Item) -> str:
 def _add_item(*t):
     global _items
     global _ii
+    global _free_item_ids
     
-    _items[_ii] = tuple(t)
-    _ii += 1
-    return _ii - 1
+    if _free_item_ids:
+        idx = _free_item_ids.pop()
+    else:
+        idx = _ii
+        _ii += 1
+    
+    _items[idx] = tuple(t)
+    return idx
 
 def _update_item(index: int, *t):
     global _items
@@ -1801,10 +1815,10 @@ def _set_item_count(index: int, count: str):
         
 def _remove_item(i):
     global _items
-    global _ti
+    global _free_item_ids
 
     del _items[i]
-    _ii -= 1
+    _free_item_ids.append(i)
 
 def _clear_items():
     global _items


### PR DESCRIPTION
_ti (and _ii) was supposed to be the length of _texts (and _items). If _texts has 3 text objects with ids 0, 1, 2, then _ti would say that there are 3 objects which means the next id should be 3 which is correct, however, there's a problem if you remove an object in the middle like in this example: lets say we have 0, 1, 2, 3, _ti is 4 because there are 4 objects, then we remove the object at index 1, we now have 0, 2, 3, _ti gets decremented to 3 and when we make the next object, it has the id 3 (0, 2, 3, 3). This is obviously not good because the only way to edit and remove text (and items) is through indexes. The new implementation keeps track of any id's that are less than the max, if we have 0, 2, 3, 5, it'll keep track of 1, 4 before checking _ti and _ii so we can recycle indexes, which I assume was the original intention.